### PR TITLE
fix no_batching=False case error

### DIFF
--- a/run_nerf.py
+++ b/run_nerf.py
@@ -166,7 +166,7 @@ def render_path(render_poses, hwf, K, chunk, render_kwargs, gt_imgs=None, savedi
             print(rgb.shape, disp.shape)
 
         if gt_imgs is not None and render_factor==0:
-            p = -10. * np.log10(np.mean(np.square(rgb.cpu().numpy() - gt_imgs[i])))
+            p = -10. * np.log10(np.mean(np.square(rgb.cpu().numpy() - (gt_imgs[i].cpu().numpy() if type(gt_imgs) == torch.Tensor else gt_imgs[i]))))
             print(p)
             psnrs.append(p)
         


### PR DESCRIPTION
Hi @yashbhalgat,
Thank you for this great work!

I just inspect the #10, then figure out is caused by the configuration file doesn't have `no_batching = True` option.
I change the code only for the psnr calculation part because I'm afraid that other change might degrade performance.
I check that the learning and rendering is OK now.

here is a rendered images after 2000 iteration(again, this is really great work!).
![000](https://user-images.githubusercontent.com/65658464/175065348-ef2d072f-a357-4f6d-b722-179c67f65002.png)


Thanks!