### PR TITLE
fixing error created by prev renaming of disps to depths in run_nerf-py

### DIFF
--- a/run_nerf.py
+++ b/run_nerf.py
@@ -197,14 +197,14 @@ def render_path(render_poses, hwf, K, chunk, render_kwargs, gt_imgs=None, savedi
 
 
     rgbs = np.stack(rgbs, 0)
-    disps = np.stack(disps, 0)
+    depths = np.stack(depths, 0)
     if gt_imgs is not None and render_factor==0:
         avg_psnr = sum(psnrs)/len(psnrs)
         print("Avg PSNR over Test set: ", avg_psnr)
         with open(os.path.join(savedir, "test_psnrs_avg{:0.2f}.pkl".format(avg_psnr)), "wb") as fp:
             pickle.dump(psnrs, fp)
 
-    return rgbs, disps
+    return rgbs, depths
 
 
 def create_nerf(args):


### PR DESCRIPTION
Changes in fed466414990dd0c840b8b45f3ec2bab801bb8ee included renaming of disps to depths
in the render_path function in run_nerf.py.
Renaming was not complete, leaving a reference to disps in line 200, causing the program to crash because of the unresolved reference.
 
Changes proposed here are just finishing the renaming by renaming all remaining references to disps to depths (this includes the var returned by the function). 